### PR TITLE
Don't lock threads

### DIFF
--- a/julia/stl.jl
+++ b/julia/stl.jl
@@ -16,7 +16,7 @@ struct Triangle
 end
 
 function parse(path::AbstractString)
-    open(path) do stl
+    open(path;lock=false) do stl
         skip(stl, 80)  # skip header
         trianglecount = read(stl, UInt32)
         ref = Ref{Triangle}()


### PR DESCRIPTION
On v1.3 if you are opening paths the I/O was made thread-safe by default, but if you don't need thread-safety it can be faster to ignore the I/O locks. See https://github.com/JuliaLang/julia/issues/34195 for details. This fixes the performance post v1.3:

Before:

```julia
689.599 μs (15 allocations: 347.34 KiB)
```

After:

```julia
243.900 μs (15 allocations: 347.34 KiB)
```