### PR TITLE
Major update for Julia code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ From the `python` directory:
 
 ```console
 $ python benchmark.py
-25150.930999999986 μs
+13513.513993530069 μs μs
 ```
 
 > Note: Python 3.7.0 is required.
@@ -66,4 +66,4 @@ $ python benchmark.py
 |----------|------------|
 | C++      | 237.056 μs |
 | Julia    | 110.646 μs |
-| Python   | 25150.9 μs |
+| Python   | 13513.5 μs |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ julia> ]
 (v1.6) pkg> add BenchmarkTools
 julia> using BenchmarkTools
 julia> include("stl.jl")
+julia> using Main.STL
 julia> @btime parse_to_stack("nist.stl")
   110.646 μs (14 allocations: 347.30 KiB)
 ```

--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ From the `julia` directory:
 ```console
 $ julia -O3
 julia> ]
-(v1.5) pkg> add BenchmarkTools
-(v1.5) pkg> *press backspace*
+(v1.6) pkg> add BenchmarkTools
 julia> using BenchmarkTools
 julia> include("stl.jl")
-julia> @btime STL.parse("nist.stl")
-  140.942 μs (14 allocations: 347.30 KiB)
+julia> @btime parse_to_stack("nist.stl")
+  110.646 μs (14 allocations: 347.30 KiB)
 ```
 
 From the `python` directory:
@@ -66,10 +65,5 @@ $ python benchmark.py
 | Language | Time       |
 |----------|------------|
 | C++      | 409.210 μs |
-| Julia    | 211.641 μs |
+| Julia    | 110.646 μs |
 | Python   | 25150.9 μs |
-
-## Disclaimer
-
-I am neither a C++ nor Julia expert. Please let me know if I biased the results
-by implementing something obviously inefficiently.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ From the `julia` directory:
 ```console
 $ julia -O3
 julia> ]
-(v1.0) pkg> add BenchmarkTools
-(v1.0) pkg> *press backspace*
+(v1.5) pkg> add BenchmarkTools
+(v1.5) pkg> *press backspace*
 julia> using BenchmarkTools
 julia> include("stl.jl")
 julia> @btime STL.parse("nist.stl")

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ CPU Caches:
 --------------------------------------------------
 Benchmark           Time           CPU Iterations
 --------------------------------------------------
-ParseStl       429234 ns     409210 ns       1729
+ParseStl       233049 ns     233047 ns       2960
 ```
 
 From the `julia` directory:
@@ -64,6 +64,6 @@ $ python benchmark.py
 
 | Language | Time       |
 |----------|------------|
-| C++      | 409.210 μs |
+| C++      | 233.049 μs |
 | Julia    | 110.646 μs |
 | Python   | 25150.9 μs |

--- a/README.md
+++ b/README.md
@@ -25,18 +25,17 @@ make -j
 Sample output
 
 ```console
-2018-10-06 12:35:31
 Running ./stl_benchmark
-Run on (8 X 2300 MHz CPU s)
+Run on (12 X 4500 MHz CPU s)
 CPU Caches:
-  L1 Data 32K (x4)
-  L1 Instruction 32K (x4)
-  L2 Unified 262K (x4)
-  L3 Unified 6291K (x1)
+  L1 Data 32K (x6)
+  L1 Instruction 32K (x6)
+  L2 Unified 256K (x6)
+  L3 Unified 12288K (x1)
 --------------------------------------------------
 Benchmark           Time           CPU Iterations
 --------------------------------------------------
-ParseStl       233049 ns     233047 ns       2960
+ParseStl       237056 ns     236744 ns       2912
 ```
 
 From the `julia` directory:
@@ -65,6 +64,6 @@ $ python benchmark.py
 
 | Language | Time       |
 |----------|------------|
-| C++      | 233.049 μs |
+| C++      | 237.056 μs |
 | Julia    | 110.646 μs |
 | Python   | 25150.9 μs |

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ From the `julia` directory:
 ```console
 $ julia -O3
 julia> ]
-(v1.0) pkg> activate .
-(benchmark) pkg> ^C
+(v1.0) pkg> add BenchmarkTools
+(v1.0) pkg> *press backspace*
 julia> using BenchmarkTools
 julia> include("stl.jl")
 julia> @btime STL.parse("nist.stl")
-  211.641 μs (9 allocations: 347.06 KiB)
+  140.942 μs (14 allocations: 347.30 KiB)
 ```
 
 From the `python` directory:

--- a/README.md
+++ b/README.md
@@ -7,19 +7,24 @@ For more information: [STL Benchmark Comparison: C++ vs. Julia](https://aaronang
 ## Getting Started
 
 ```console
-$ git clone --recurse-submodules git@github.com:XInvisib1eX/stl-benchmark.git
+git clone --recurse-submodules git@github.com:XInvisib1eX/stl-benchmark.git
 ```
 
 From the `cpp` directory:
 
 ```console
-$ export CC=/usr/bin/clang
-$ export CXX=/usr/bin/clang++
-$ mkdir build
-$ cd build
-$ cmake -DCMAKE_BUILD_TYPE=Release ..
-$ make -j
-$ ./stl_benchmark
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j
+./stl_benchmark
+```
+
+Sample output
+
+```console
 2018-10-06 12:35:31
 Running ./stl_benchmark
 Run on (8 X 2300 MHz CPU s)

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ julia> ]
 (v1.6) pkg> add BenchmarkTools
 julia> using BenchmarkTools
 julia> include("stl.jl")
-julia> using Main.STL
-julia> @btime parse("nist.stl")
+julia> @btime STL.parse("nist.stl")
   110.646 μs (14 allocations: 347.30 KiB)
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more information: [STL Benchmark Comparison: C++ vs. Julia](https://aaronang
 ## Getting Started
 
 ```console
-$ git clone --recurse-submodules git@github.com:aaronang/stl-benchmark.git
+$ git clone --recurse-submodules git@github.com:XInvisib1eX/stl-benchmark.git
 ```
 
 From the `cpp` directory:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For more information: [STL Benchmark Comparison: C++ vs. Julia](https://aaronang
 ## Getting Started
 
 ```console
-git clone --recurse-submodules git@github.com:XInvisib1eX/stl-benchmark.git
+git clone --recurse-submodules git@github.com:pddshk/stl-benchmark.git
 ```
 
 NB! to run this you need to place `#include <limits>` into cpp/benchmark/src/benchmark_register.h

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ julia> ]
 julia> using BenchmarkTools
 julia> include("stl.jl")
 julia> using Main.STL
-julia> @btime parse_to_stack("nist.stl")
+julia> @btime parse("nist.stl")
   110.646 μs (14 allocations: 347.30 KiB)
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For more information: [STL Benchmark Comparison: C++ vs. Julia](https://aaronang
 git clone --recurse-submodules git@github.com:XInvisib1eX/stl-benchmark.git
 ```
 
+NB! to run this you need to place `#include <limits>` into cpp/benchmark/src/benchmark_register.h
+
 From the `cpp` directory:
 
 ```console

--- a/julia/stl.jl
+++ b/julia/stl.jl
@@ -15,18 +15,19 @@ struct Triangle
     v3::Vertex
 end
 
-function parse(path::AbstractString)
-    open(path) do stl
-        skip(stl, 80)  # skip header
-        trianglecount = read(stl, UInt32)
-        ref = Ref{Triangle}()
-        triangles = map(1:trianglecount) do i
-            read!(stl, ref)
-            skip(stl, 2)  # skip attribute byte count
-            ref[]
+function parse(path)
+    open(path; lock = false) do io
+    	skip(io, 80) # skip header 
+	triangle_count = read(io, UInt32)
+    	triangles = Vector{Triangle}(undef, triangle_count) # preallocate memory for triangles 
+    	dest = Base.unsafe_convert(Ptr{Triangle}, triangles) # destination pointer
+    	unsafe_read(io, dest, sizeof(Triangle)) # copying first triangle
+        for _ in 2:triangle_count
+	    skip(io, 2)
+	    dest += 48 # moving to the next trianlge in dest
+	    unsafe_read(io, dest, sizeof(Triangle))
         end
-        @assert eof(stl)
-        return triangles
+    	triangles
     end
 end
 

--- a/julia/stl.jl
+++ b/julia/stl.jl
@@ -26,7 +26,7 @@ function parse(path)
     	unsafe_read(io, dest, sizeof(Triangle)) # copying first triangle
         for _ in 2:triangle_count
             skip(io, 2)
-            dest += 48 # moving to the next trianlge in dest
+            dest += sizeof(Triangle) # moving to the next trianlge in dest
             unsafe_read(io, dest, sizeof(Triangle))
         end
         triangles
@@ -42,7 +42,7 @@ function parse_malloc(path)
         unsafe_read(io, dest, sizeof(Triangle)) # copying first triangle
         for _ in 2:triangle_count
             skip(io, 2)
-            dest += 48 # moving to the next trianlge in dest
+            dest += sizeof(Triangle) # moving to the next trianlge in dest
             unsafe_read(io, dest, sizeof(Triangle))
         end
         Base.unsafe_wrap(Array, triangles, triangle_count; own = true)

--- a/julia/stl.jl
+++ b/julia/stl.jl
@@ -1,6 +1,6 @@
 module STL
 
-export parse_to_stack, parse_to_heap
+export parse, parse_malloc
 
 struct Vertex
     x::Float32
@@ -17,7 +17,7 @@ struct Triangle
     v3::Vertex
 end
 
-function parse_to_stack(path)
+function parse(path)
     open(path; lock = false) do io
     	skip(io, 80) # skip header 
         triangle_count = read(io, UInt32)
@@ -33,7 +33,7 @@ function parse_to_stack(path)
     end
 end
 
-function parse_to_heap(path)
+function parse_malloc(path)
     open(path; lock = false) do io
         skip(io, 80)
         triangle_count = read(io, UInt32)

--- a/julia/stl.jl
+++ b/julia/stl.jl
@@ -37,7 +37,7 @@ function parse_malloc(path)
     open(path; lock = false) do io
         skip(io, 80)
         triangle_count = read(io, UInt32)
-        triangles = convert(Ptr{Triangle}, Base.Libc.malloc(48triangle_count))
+        triangles = convert(Ptr{Triangle}, Base.Libc.malloc(sizeof(Triangle)*triangle_count))
         dest = triangles
         unsafe_read(io, dest, sizeof(Triangle)) # copying first triangle
         for _ in 2:triangle_count


### PR DESCRIPTION
It speeds up Julia code ~5 times in comparison with origin. 

1. Unlocked threads with `open(path; lock = false)`
2. Preallocated memory for resulting vector `triangles = Vector{Triangle}(undef, triangle_count)`
3. Used `unsafe_read` and pointer to read from file directly to memory